### PR TITLE
make struct rebinding.name a const char *

### DIFF
--- a/fishhook.h
+++ b/fishhook.h
@@ -36,7 +36,7 @@ extern "C" {
  * name to its replacement
  */
 struct rebinding {
-  char *name;
+  const char *name;
   void *replacement;
 };
 


### PR DESCRIPTION
fishhook doesn't need to modify the content of the string; let's commit to it