### PR TITLE
Update Fishhook Podspec to refer to the latest API-Changing Commit instead of Release 0.1.

### DIFF
--- a/fishhook.podspec
+++ b/fishhook.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |spec|
   spec.name             = "fishhook"
-  spec.version          = "0.1"
+  spec.version          = "0.1.1"
   spec.license          = { :type => "BSD", :file => "LICENSE" }
   spec.homepage         = 'https://github.com/facebook/fishhook'
   spec.author           = { "Facebook, Inc." => "https://github.com/facebook" }
   spec.summary          = "A library that enables dynamically rebinding symbols in Mach-O binaries running on iOS."
-  spec.source           = { :git => "https://github.com/facebook/fishhook.git", :tag => '0.1'}
+  spec.source           = { :git => "https://github.com/facebook/fishhook.git", :commit => '8dbd09bb8a6e89c8f37d23e23eb68d1c1dab9614'}
   spec.source_files     = "fishhook.{h,c}"
   spec.social_media_url = 'https://twitter.com/fbOpenSource'
 


### PR DESCRIPTION
Related Issue : https://github.com/facebook/fishhook/issues/20

When the pull request - https://github.com/facebook/fishhook/pull/18 was merged, it broke the API for anyone using fishhook with CocoaPods since the repo at HEAD has a different interface from the Pods Sources.

In the Podspec, we are currently using the release version of fishhook. However, creating releases can be extremely tedious, especially with the case of a single maintainer and it would be much better if we could simply point to a specific commit. 