### PR TITLE
Improve performance of perform_rebinding_with_section

### DIFF
--- a/fishhook.c
+++ b/fishhook.c
@@ -76,6 +76,15 @@ static int prepend_rebindings(struct rebindings_entry **rebindings_head,
   return 0;
 }
 
+static bool str_longer(const char *symbol, size_t len) {
+  for (size_t i = 0; i <= len; i++) {
+    if (symbol[i] == 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
 static void perform_rebinding_with_section(struct rebindings_entry *rebindings,
                                            section_t *section,
                                            intptr_t slide,
@@ -95,7 +104,7 @@ static void perform_rebinding_with_section(struct rebindings_entry *rebindings,
     struct rebindings_entry *cur = rebindings;
     while (cur) {
       for (uint j = 0; j < cur->rebindings_nel; j++) {
-        if (strlen(symbol_name) > 1 &&
+        if (str_longer(symbol_name, 1) &&
             strcmp(&symbol_name[1], cur->rebindings[j].name) == 0) {
           if (cur->rebindings[j].replaced != NULL &&
               indirect_symbol_bindings[i] != cur->rebindings[j].replacement) {


### PR DESCRIPTION
This function was using a full strlen check just to check that the length was greater than 1 so it could index into position 1. This forces us to walk the entire length of the symbol when we don't really need to. I noticed that this was pretty slow on iPhone 4, so wrote a little function that just checks that the string is longer than the given value, then returns.

On my iPhone 4 this cuts the runtime of this function from about 100 ms. to about 55-60 ms. On my iPhone 6S, it goes from 15 ms. to 7 ms.