### PR TITLE
Make fishhook symbols hidden by default

### DIFF
--- a/fishhook.h
+++ b/fishhook.h
@@ -27,6 +27,12 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#if !defined(FISHHOOK_EXPORT)
+#define FISHHOOK_VISIBILITY __attribute__((visibility("hidden")))
+#else
+#define FISHHOOK_VISIBILITY __attribute__((visibility("default")))
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif //__cplusplus
@@ -49,12 +55,14 @@ struct rebinding {
  * rebind are added to the existing list of rebindings, and if a given symbol
  * is rebound more than once, the later rebinding will take precedence.
  */
+FISHHOOK_VISIBILITY
 int rebind_symbols(struct rebinding rebindings[], size_t rebindings_nel);
 
 /*
  * Rebinds as above, but only in the specified image. The header should point
  * to the mach-o header, the slide should be the slide offset. Others as above.
  */
+FISHHOOK_VISIBILITY
 int rebind_symbols_image(void *header,
                          intptr_t slide,
                          struct rebinding rebindings[],


### PR DESCRIPTION
Now when fishhook is included in a library/framework, fishhook functions will no longer be exported from that library. Unless specifically configured to. This seems like the right thing to do by default, and prevents issues that can arise from multiple embedded instances of fishhook.