### PR TITLE
Two-level namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,10 @@ int my_open(const char *path, int oflag, ...) {
 int main(int argc, char * argv[])
 {
   @autoreleasepool {
-    rebind_symbols((struct rebinding[2]){{"close", my_close, (void *)&orig_close}, {"open", my_open, (void *)&orig_open}}, 2);
+    rebind_symbols((struct rebinding[2]){
+      {"close", "/usr/lib/libSystem.B.dylib", my_close, (void *)&orig_close},
+      {"open", "/usr/lib/libSystem.B.dylib", my_open, (void *)&orig_open}
+    }, 2);
  
     // Open our own binary and print out first 4 bytes (which is the same
     // for all Mach-O binaries on a given architecture)

--- a/fishhook.c
+++ b/fishhook.c
@@ -106,9 +106,10 @@ static void perform_rebinding_with_section(struct rebindings_entry *rebindings,
     struct rebindings_entry *cur = rebindings;
     while (cur) {
       for (uint j = 0; j < cur->rebindings_nel; j++) {
-        if (dylib_ordinal != cur->dylib_ordinals[j] && dylib_ordinal != SELF_LIBRARY_ORDINAL) {
+        if (cur->dylib_ordinals[j] != 0 && dylib_ordinal != cur->dylib_ordinals[j] && dylib_ordinal != SELF_LIBRARY_ORDINAL) {
           continue;
         }
+
         if (strcmp(&symbol_name[1], cur->rebindings[j].name) == 0) {
           if (cur->rebindings[j].replaced != NULL &&
               indirect_symbol_bindings[i] != cur->rebindings[j].replacement) {
@@ -162,7 +163,9 @@ static void rebind_symbols_for_image(struct rebindings_entry *rebindings,
         for (struct rebindings_entry *entry = rebindings; entry != NULL; entry = entry->next) {
           for (int el = 0; el < entry->rebindings_nel; ++el) {
             struct rebinding *cur_rebinding = &entry->rebindings[el];
-            if (strcmp(cur_rebinding->dylib, dylib) == 0) {
+            if (cur_rebinding->dylib == NULL) {
+              image_has_dylibs_to_rebind = true;
+            } else if (strcmp(cur_rebinding->dylib, dylib) == 0) {
               entry->dylib_ordinals[el] = cur_dylib_ordinal;
               image_has_dylibs_to_rebind = true;
             }

--- a/fishhook.c
+++ b/fishhook.c
@@ -121,22 +121,23 @@ static void rebind_symbols_for_image(struct rebindings_entry *rebindings,
     return;
   }
 
-  segment_command_t *cur_seg_cmd;
+  struct load_command *cur_load_cmd;
   segment_command_t *linkedit_segment = NULL;
   struct symtab_command* symtab_cmd = NULL;
   struct dysymtab_command* dysymtab_cmd = NULL;
 
   uintptr_t cur = (uintptr_t)header + sizeof(mach_header_t);
-  for (uint i = 0; i < header->ncmds; i++, cur += cur_seg_cmd->cmdsize) {
-    cur_seg_cmd = (segment_command_t *)cur;
-    if (cur_seg_cmd->cmd == LC_SEGMENT_ARCH_DEPENDENT) {
-      if (strcmp(cur_seg_cmd->segname, SEG_LINKEDIT) == 0) {
-        linkedit_segment = cur_seg_cmd;
+  for (uint i = 0; i < header->ncmds; i++, cur += cur_load_cmd->cmdsize) {
+    cur_load_cmd = (struct load_command *)cur;
+    if (cur_load_cmd->cmd == LC_SEGMENT_ARCH_DEPENDENT) {
+      segment_command_t *seg_cmd = (segment_command_t *)cur_load_cmd;
+      if (strcmp(seg_cmd->segname, SEG_LINKEDIT) == 0) {
+        linkedit_segment = seg_cmd;
       }
-    } else if (cur_seg_cmd->cmd == LC_SYMTAB) {
-      symtab_cmd = (struct symtab_command*)cur_seg_cmd;
-    } else if (cur_seg_cmd->cmd == LC_DYSYMTAB) {
-      dysymtab_cmd = (struct dysymtab_command*)cur_seg_cmd;
+    } else if (cur_load_cmd->cmd == LC_SYMTAB) {
+      symtab_cmd = (struct symtab_command*)cur_load_cmd;
+    } else if (cur_load_cmd->cmd == LC_DYSYMTAB) {
+      dysymtab_cmd = (struct dysymtab_command*)cur_load_cmd;
     }
   }
 
@@ -154,14 +155,15 @@ static void rebind_symbols_for_image(struct rebindings_entry *rebindings,
   uint32_t *indirect_symtab = (uint32_t *)(linkedit_base + dysymtab_cmd->indirectsymoff);
 
   cur = (uintptr_t)header + sizeof(mach_header_t);
-  for (uint i = 0; i < header->ncmds; i++, cur += cur_seg_cmd->cmdsize) {
-    cur_seg_cmd = (segment_command_t *)cur;
-    if (cur_seg_cmd->cmd == LC_SEGMENT_ARCH_DEPENDENT) {
-      if (strcmp(cur_seg_cmd->segname, SEG_DATA) != 0 &&
-          strcmp(cur_seg_cmd->segname, SEG_DATA_CONST) != 0) {
+  for (uint i = 0; i < header->ncmds; i++, cur += cur_load_cmd->cmdsize) {
+    cur_load_cmd = (struct load_command *)cur;
+    if (cur_load_cmd->cmd == LC_SEGMENT_ARCH_DEPENDENT) {
+      segment_command_t *seg_cmd = (segment_command_t *)cur_load_cmd;
+      if (strcmp(seg_cmd->segname, SEG_DATA) != 0 &&
+          strcmp(seg_cmd->segname, SEG_DATA_CONST) != 0) {
         continue;
       }
-      for (uint j = 0; j < cur_seg_cmd->nsects; j++) {
+      for (uint j = 0; j < seg_cmd->nsects; j++) {
         section_t *sect =
           (section_t *)(cur + sizeof(segment_command_t)) + j;
         if ((sect->flags & SECTION_TYPE) == S_LAZY_SYMBOL_POINTERS) {

--- a/fishhook.c
+++ b/fishhook.c
@@ -129,15 +129,22 @@ static void rebind_symbols_for_image(struct rebindings_entry *rebindings,
   uintptr_t cur = (uintptr_t)header + sizeof(mach_header_t);
   for (uint i = 0; i < header->ncmds; i++, cur += cur_load_cmd->cmdsize) {
     cur_load_cmd = (struct load_command *)cur;
-    if (cur_load_cmd->cmd == LC_SEGMENT_ARCH_DEPENDENT) {
-      segment_command_t *seg_cmd = (segment_command_t *)cur_load_cmd;
-      if (strcmp(seg_cmd->segname, SEG_LINKEDIT) == 0) {
-        linkedit_segment = seg_cmd;
+    switch (cur_load_cmd->cmd) {
+      case LC_SEGMENT_ARCH_DEPENDENT: {
+        segment_command_t *seg_cmd = (segment_command_t *)cur_load_cmd;
+        if (strcmp(seg_cmd->segname, SEG_LINKEDIT) == 0) {
+          linkedit_segment = seg_cmd;
+        }
+        break;
       }
-    } else if (cur_load_cmd->cmd == LC_SYMTAB) {
-      symtab_cmd = (struct symtab_command*)cur_load_cmd;
-    } else if (cur_load_cmd->cmd == LC_DYSYMTAB) {
-      dysymtab_cmd = (struct dysymtab_command*)cur_load_cmd;
+      case LC_SYMTAB:
+        symtab_cmd = (struct symtab_command*)cur_load_cmd;
+        break;
+      case LC_DYSYMTAB:
+        dysymtab_cmd = (struct dysymtab_command*)cur_load_cmd;
+        break;
+      default:
+        break;
     }
   }
 

--- a/fishhook.h
+++ b/fishhook.h
@@ -43,6 +43,7 @@ extern "C" {
  */
 struct rebinding {
   const char *name;
+  const char *dylib;
   void *replacement;
   void **replaced;
 };


### PR DESCRIPTION
This change adds support for rebinding that leverages mach-o's two-level namespace.

The tl;dr of two-level namespaces is that symbols imported from other libraries will reference which library they came from. When rebinding a symbol by name alone, it's possible to unintentionally rebind symbols that happen to have the same name, which can cause unexpected results. Using the two-level namespace prevents the mysterious bugs and crashes that can happen when rebinding by just symbol name alone.

In addition to correctness, this change opens a new performance optimization, see 7cc05152e959e16f81ab61fba3b33c872fc687b8.

This change is a breaking change: callers of `rebind_symbols` now need to fill in a `dylib` field on the `rebinding` struct. This field can be `NULL` to opt-out of two-level namespaces, and enable the previous global search.

Resolves #32 
