### PR TITLE
Prevent nullptr derefence on failed allocation

### DIFF
--- a/fishhook.c
+++ b/fishhook.c
@@ -186,7 +186,7 @@ int rebind_symbols_image(void *header,
     struct rebindings_entry *rebindings_head = NULL;
     int retval = prepend_rebindings(&rebindings_head, rebindings, rebindings_nel);
     rebind_symbols_for_image(rebindings_head, (const struct mach_header *) header, slide);
-    if (rebindings_head->rebindings) {
+    if (rebindings_head) {
       free(rebindings_head->rebindings);
     }
     free(rebindings_head);


### PR DESCRIPTION
Addresses the nullptr dereference introduced in https://github.com/facebook/fishhook/commit/06cfb582bd9279879894bfd9cc9e562cc6e4b01e when fixing a memory leak.