### PR TITLE
Added safety checks to fishhook.c

### DIFF
--- a/fishhook.c
+++ b/fishhook.c
@@ -102,7 +102,9 @@ static void perform_rebinding_with_section(struct rebindings_entry *rebindings,
               indirect_symbol_bindings[i] != cur->rebindings[j].replacement) {
             *(cur->rebindings[j].replaced) = indirect_symbol_bindings[i];
           }
-          indirect_symbol_bindings[i] = cur->rebindings[j].replacement;
+          if (i < ( sizeof(indirect_symbol_bindings) / sizeof(indirect_symbol_bindings[0]))) {
+	          indirect_symbol_bindings[i] = cur->rebindings[j].replacement;
+	        }
           goto symbol_loop;
         }
       }

--- a/fishhook.c
+++ b/fishhook.c
@@ -103,8 +103,8 @@ static void perform_rebinding_with_section(struct rebindings_entry *rebindings,
             *(cur->rebindings[j].replaced) = indirect_symbol_bindings[i];
           }
           if (i < ( sizeof(indirect_symbol_bindings) / sizeof(indirect_symbol_bindings[0]))) {
-	          indirect_symbol_bindings[i] = cur->rebindings[j].replacement;
-	        }
+	  	indirect_symbol_bindings[i] = cur->rebindings[j].replacement;
+	  }
           goto symbol_loop;
         }
       }


### PR DESCRIPTION
Fixes a crash that would occur on devices running iOS 13. `fishhook.c` would access bad memory, this adds safety checks to the offending line. This fixes #61 