### PR TITLE
If hooking in __DATA_CONST, make writable before trying to write

### DIFF
--- a/fishhook.c
+++ b/fishhook.c
@@ -24,8 +24,10 @@
 #include "fishhook.h"
 
 #include <dlfcn.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/mman.h>
 #include <sys/types.h>
 #include <mach-o/dyld.h>
 #include <mach-o/loader.h>
@@ -82,8 +84,12 @@ static void perform_rebinding_with_section(struct rebindings_entry *rebindings,
                                            nlist_t *symtab,
                                            char *strtab,
                                            uint32_t *indirect_symtab) {
+  const bool isDataConst = strcmp(section->segname, "__DATA_CONST") == 0;
   uint32_t *indirect_symbol_indices = indirect_symtab + section->reserved1;
   void **indirect_symbol_bindings = (void **)((uintptr_t)slide + section->addr);
+  if (isDataConst) {
+    mprotect(indirect_symbol_bindings, section->size, PROT_READ | PROT_WRITE);
+  }
   for (uint i = 0; i < section->size / sizeof(void *); i++) {
     uint32_t symtab_index = indirect_symbol_indices[i];
     if (symtab_index == INDIRECT_SYMBOL_ABS || symtab_index == INDIRECT_SYMBOL_LOCAL ||
@@ -109,6 +115,9 @@ static void perform_rebinding_with_section(struct rebindings_entry *rebindings,
       cur = cur->next;
     }
   symbol_loop:;
+  }
+  if (isDataConst) {
+    mprotect(indirect_symbol_bindings, section->size, PROT_READ);
   }
 }
 


### PR DESCRIPTION
iOS 13 seems to have thrown us off. Apparently, __DATA_CONST is set read-only after dyld runs.

Fixes #61 