### PR TITLE
fixFBRetainCycleDetectorIssues96

### DIFF
--- a/fishhook.c
+++ b/fishhook.c
@@ -134,7 +134,9 @@ static void perform_rebinding_with_section(struct rebindings_entry *rebindings,
               indirect_symbol_bindings[i] != cur->rebindings[j].replacement) {
             *(cur->rebindings[j].replaced) = indirect_symbol_bindings[i];
           }
-          indirect_symbol_bindings[i] = cur->rebindings[j].replacement;
+            if(i < (sizeof(indirect_symbol_bindings) /sizeof(indirect_symbol_bindings[0]))) {
+               indirect_symbol_bindings[i] = cur->rebindings[j].replacement;
+            }
           goto symbol_loop;
         }
       }


### PR DESCRIPTION
fix [fishhook.c crash](https://github.com/facebook/FBRetainCycleDetector/issues/96)